### PR TITLE
update LLLplus URL because of new username

### DIFF
--- a/L/LLLplus/Package.toml
+++ b/L/LLLplus/Package.toml
@@ -1,3 +1,3 @@
 name = "LLLplus"
 uuid = "142c1900-a1c3-58ae-a66d-b187f9ca6423"
-repo = "https://github.com/christianpeel/LLLplus.jl.git"
+repo = "https://github.com/chrisvwx/LLLplus.jl.git"


### PR DESCRIPTION
Changed my username from "christianpeel" to "chrisvwx"; this PR changes the URL of LLLplus accordingly